### PR TITLE
Corrected crash on diagnostic calls

### DIFF
--- a/myhome-cover.js
+++ b/myhome-cover.js
@@ -11,17 +11,17 @@ module.exports = function(RED) {
       var payload = {}
 
       // check if message is a status update
-      if(new RegExp('\\*2\\*0\\*(' + config.coverid + '|0)##').test(packet)) {  // stopped
+      if(new RegExp('^\\*2\\*0\\*(' + config.coverid + '|0)##').test(packet)) {  // stopped
         node.status({fill: 'yellow', shape: 'dot', text: 'STOP'})
         // node.send({payload: "STOP", topic: 'state/' + config.topic})
         return
       }
-      if(new RegExp('\\*2\\*1\\*(' + config.coverid + '|0)##').test(packet)) {  // stopped
+      if(new RegExp('^\\*2\\*1\\*(' + config.coverid + '|0)##').test(packet)) {  // stopped
         node.status({fill: 'yellow', shape: 'dot', text: 'OPEN'})
         node.send({payload: "open", topic: 'state/' + config.topic})
         return
       }
-      if(new RegExp('\\*2\\*2\\*(' + config.coverid + '|0)##').test(packet)) {  // stopped
+      if(new RegExp('^\\*2\\*2\\*(' + config.coverid + '|0)##').test(packet)) {  // stopped
         node.status({fill: 'yellow', shape: 'dot', text: 'CLOSE'})
         node.send({payload: "closed", topic: 'state/' + config.topic})
         return


### PR DESCRIPTION
Corrected #6 : the problem was caused with diagnostics call (WHO = 1001, 1004 or 1013) for which responses are quite long...
The regex used to filter could then find a part (within the command) which looked like light updates.
ex: *#1001*0*30*1*400*0##
where the end of it (1*400*0##) is similar to a light/switch change, which it is not...
Changed to ensure the regexp is tested at the start of the string and not in the middle of it.